### PR TITLE
Docs: technically we could break `juliaup-version` in a patch release

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See the [Juliaup README](https://github.com/JuliaLang/juliaup/blob/main/README.m
 
 ## Private internals
 
-The `juliaup-version` input is a private internal and is not part of the public API of this action. Therefore, in a future non-breaking (minor) release of this action, we are allowed to:
+The `juliaup-version` input is a private internal and is not part of the public API of this action. Therefore, in a future non-breaking (minor or patch) release of this action, we are allowed to:
 1. Rename the input.
 2. Remove the input altogether.
 3. Change the default value of the input.


### PR DESCRIPTION
We'd probably choose to do a minor release, but we are technically allowed to do it in a patch.