### PR TITLE
CI: Don't use `continue-on-error`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,9 +161,11 @@ jobs:
           echo "PATH is: ${PATH:?}"
           which -a julia
           julia --version
-          which -a juliaup
-          juliaup --version
-        continue-on-error: true
+          # We allow the next few commands to error
+          # (exit with nonzero exit code) without
+          # failing the whole build:
+          which -a juliup || echo "Command failed: which -a juliup"
+          juliaup --version || echo "Command failed: juliaup --version"
       - name: Run the local copy of this action (that is checked in to source control)
         uses: ./
         with:


### PR DESCRIPTION
When we use `continue-on-error: true`, we still end up with a bunch of error (red) GitHub annotations, which is noisy.

So instead, let's get rid of our use of `continue-on-error`, and manually do `cmd || echo "some message"` for the specific commands that we want to allow to fail.