### PR TITLE
Remove the `version` field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,6 @@
   "packages": {
     "": {
       "name": "install-juliaup",
-      "version": "1.0.0-DEV",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,6 @@
   "name": "install-juliaup",
   "description": "GitHub Action to install juliaup",
   "main": "lib/entrypoint.js",
-  "version": "1.0.0-DEV",
   "author": "julia-actions organization, contributors",
   "private": true,
   "homepage": "https://github.com/julia-actions/install-juliaup",


### PR DESCRIPTION
This PR removes the `version` field from `package.json` and `package-lock.json`.

## Motivation

I always forget to update this field.