### PR TITLE
CI: stop using `continue-on-error`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,13 +147,13 @@ jobs:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633
         with:
           persist-credentials: false
-      - name: '[before] Print some output for debugging purposes [allow this step to fail]'
+      - name: '[before] Print some output for debugging purposes'
         shell: bash
         run: |
           set -x
           echo "PATH is: ${PATH:?}"
-          which -a julia
-          julia --version
+          # which -a julia
+          # julia --version
           # which -a juliaup
           # juliaup --version
         # continue-on-error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,9 +154,13 @@ jobs:
           echo "PATH is: ${PATH:?}"
           which -a julia
           julia --version
-          which -a juliaup
-          juliaup --version
-        continue-on-error: true
+          # which -a juliaup
+          # juliaup --version
+        # continue-on-error: true
+        # Note: we intentionally do not use `continue-on-error` for individual job steps.
+        # If you use `continue-on-error` for an individual job step, then if that job
+        # step fails, it prints a bunch of "error" annotations in the "Annotations" section.
+        # This is quite noisy and not helpful.
       - name: Run the local copy of this action (that is checked in to source control)
         uses: ./
         with:


### PR DESCRIPTION
In this PR, we stop using `continue-on-error` on individual job steps in the CI workflow file.

## Motivation

If you use `continue-on-error` for an individual job step, then if that job step fails, it prints a bunch of "error" annotations in the "Annotations" section. This is quite noisy and not helpful.

Example screenshot of the problem:

<img src="https://github.com/julia-actions/install-juliaup/assets/5619885/b19cc681-c895-4e57-9f65-c7610b7c7bdd" width="30%" height="30%">