### PR TITLE
Update to Juliaup 1.17.4

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ inputs:
   internal-juliaup-version:
     description: '[private internal]. The Juliaup version to install. This is not part of the public API of this action.'
     required: false
-    default: '1.15.0' # Update this value whenever a new release of Juliaup is made.
+    default: '1.17.4' # Update this value whenever a new release of Juliaup is made.
 runs:
   using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
Juliaup 1.17.4 is currently listed as the latest release on GitHub: https://github.com/JuliaLang/juliaup/releases/tag/v1.17.4