### PR TITLE
CI: Remove the Tagcheck CI jobs for full-hash and v$major.minor.patch (keep the Tagcheck CI job for v$major)

### DIFF
--- a/.github/workflows/tagcheck.yml
+++ b/.github/workflows/tagcheck.yml
@@ -20,36 +20,6 @@ concurrency:
 permissions:
   contents: read
 jobs:
-  tagcheck-hash:
-    timeout-minutes: 10
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-    steps:
-      # We use Dependabot to automatically update the following line:
-      - uses: julia-actions/install-juliaup@645c8ab13ebf407f60a7f298c4102eb7e2145094 # v3.1.2
-        with:
-          channel: '1'
-      - run: julia --version
-      - run: julia -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'
-  tagcheck-version:
-    timeout-minutes: 10
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - ubuntu-latest
-    steps:
-      # We use Dependabot to automatically update the following line:
-      - uses: julia-actions/install-juliaup@v3.1.2
-        with:
-          channel: '1'
-      - run: julia --version
-      - run: julia -e 'import InteractiveUtils; InteractiveUtils.versioninfo()'
   tagcheck-convenience:
     timeout-minutes: 10
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
The goal of the Tagcheck CI job is to make sure that the latest tagged version of this action runs without any errors. In order to achieve this goal, I think it's sufficient to check the `v$major` tag, which is the tag that most people follow.

So this PR removes the Tagcheck jobs for full-commit-hash and `v$major.minor.patch`. This reduces churn in this repo, because we don't have to constantly keep those lines up-to-date.