### PR TITLE
Renovate: Set a 7-day cooldown

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "minimumReleaseAge": "7 days",
   "osvVulnerabilityAlerts": true,
   "rebaseWhen": "conflicted",
+  // Security updates bypass minimumReleaseAge, so vulnerability PRs stay immediate:
+  // https://docs.renovatebot.com/key-concepts/minimum-release-age/#what-happens-to-security-updates
   "vulnerabilityAlerts": {
     "labels": ["security"],
     "vulnerabilityFixStrategy": "lowest"


### PR DESCRIPTION
This PR adds a 7-day Renovate cooldown for normal dependency updates.

The PR also documents that Renovate security updates bypass `minimumReleaseAge`, with a link to the Renovate docs.

## Why security and vulnerability updates are not delayed

From the Renovate docs (https://docs.renovatebot.com/key-concepts/minimum-release-age/#what-happens-to-security-updates):

> What happens to security updates?
>
> Security updates bypass any minimumReleaseAge checks, and so will be raised as soon as Renovate detects them.

🤖 Generated by OpenAI Codex.