### PR TITLE
Set the NPM cooldown in the `.npmrc` file for local usage

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 engine-strict=true
+min-release-age=7


### PR DESCRIPTION
This mirrors the Dependabot cooldown (#215), but this PR is for local usage.

Depends on:
- [x] #216

🤖 Co-authored-by: OpenAI Codex <codex@openai.com>
