### PR TITLE
README: Mention that other tools (other than Dependabot) would also work

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,11 @@ When the `install-juliaup` action runs, it adds `juliaup` to the PATH. Therefore
 - run: juliaup status
 ```
 
-## Using Dependabot version updates to keep your GitHub Actions up to date
+## Keeping your GitHub Actions up to date
 
-We highly recommend that you set up Dependabot version updates on your repo to keep your GitHub Actions up to date.
+We highly recommend that you set up a tool to keep your GitHub Actions up to date.
+
+One such tool is Dependabot, although you could use a different tool if you want.
 
 To set up Dependabot version updates, create a file named `.github/dependabot.yml` in your repo with the following contents:
 


### PR DESCRIPTION
I don't think we need to recommend Dependabot specifically. Other tools (such as Renovate) would work. The important thing is that users use some tool.

But giving Dependabot as an example still makes sense, I think. Because it comes built-in to GitHub.